### PR TITLE
Add trivy vulnerability scan summary to results

### DIFF
--- a/cmd/kube-score/cmd/release.go
+++ b/cmd/kube-score/cmd/release.go
@@ -54,7 +54,7 @@ func validateFlags(args []string) error {
 func init() {
 	releaseCmd.PersistentFlags().StringVar(&opts.Version, "version", "", "kubernetes release version")
 	releaseCmd.PersistentFlags().StringVar(&opts.OutputFormat, "output", "stdout", "output format (stdout, json) (default: stdout)")
-	releaseCmd.PersistentFlags().StringVar(&opts.ConfigFilepath, "config", ".kube_score.yaml", "kube-scopre config file (default: .kube_score.yaml")
+	releaseCmd.PersistentFlags().StringVar(&opts.ConfigFilepath, "config", ".kube_score_use.yaml", "kube-scopre config file (default: .kube_score.yaml")
 	releaseCmd.PersistentFlags().BoolVar(&opts.ListVersions, "list", false, "list recent kubernetes releases (recent 20)")
 	releaseCmd.PersistentFlags().StringVar(&opts.Distribution, "dist", "k8s", "kubernetes distribution (k8s, rke) (default: k8s)")
 	// _ = releaseCmd.MarkPersistentFlagRequired("version")

--- a/pkg/actions/vulns/trivy.go
+++ b/pkg/actions/vulns/trivy.go
@@ -19,35 +19,49 @@ import (
 
 const (
 	// Define the command template
-	scanContainerCmd = "/opt/homebrew/bin/trivy image -f json -o {{.OutputFile}} {{.URL}}"
+	scanContainerCmd = `{{.Trivy}} image -f json -o {{.OutputFile}} {{.URL}}`
 )
 
-type VulnerabilityReport struct {
-	Target          string `json:"Target"`
-	Type            string `json:"Type"`
-	Vulnerabilities []struct {
-		Id               string    `json:"VulnerabilityID"`
-		PkgName          string    `json:"PkgName"`
-		InstalledVersion string    `json:"InstalledVersion"`
-		Title            string    `json:"Title"`
-		Severity         string    `json:"Severity"`
-		CWEs             []string  `json:"CweIDs"`
-		PublishedAt      time.Time `json:"PublishedDate"`
-		LastModified     time.Time `json:"LastModifiedDate"`
-	} `json:"Vulnerabilities"`
+type Vulnerability struct {
+	Id               string    `json:"VulnerabilityID"`
+	PkgName          string    `json:"PkgName"`
+	InstalledVersion string    `json:"InstalledVersion"`
+	Title            string    `json:"Title"`
+	Severity         string    `json:"Severity"`
+	CWEs             []string  `json:"CweIDs"`
+	PublishedAt      time.Time `json:"PublishedDate"`
+	LastModified     time.Time `json:"LastModifiedDate"`
+	FixedVersion     string    `json:"FixedVersion"`
 }
 
+type VulnerabilityReport struct {
+	Target          string          `json:"Target"`
+	Type            string          `json:"Type"`
+	Vulnerabilities []Vulnerability `json:"Vulnerabilities"`
+}
+
+type TrivyResult struct {
+	SchemaVersion int                   `json:"SchemaVersion"`
+	Results       []VulnerabilityReport `json:"Results"`
+}
 type TrivyScanner struct {
 }
 
 func (scanner *TrivyScanner) ScanImage(ctx context.Context, imageURL string) (*reports.VulnerabilityData, error) {
 	vulnsummary := reports.VulnerabilityData{}
-	vulns := []VulnerabilityReport{}
 
 	os.Setenv("https_proxy", "")
 	os.Setenv("HTTPS_PROXY", "")
 
-	os.Chmod("/opt/homebrew/bin/trivy", 0755)
+	// check for presence of trivy
+	whichOut, err := exec.Command("which", "trivy").Output()
+	if err != nil {
+		fmt.Println("failed to locate trivy binary:", err)
+		return nil, err
+	}
+	trivyPath := strings.TrimSpace(string(whichOut))
+
+	os.Chmod(trivyPath, 0755)
 	cmdTmpl, err := template.New("trivyScanCmd").Parse(scanContainerCmd)
 	if err != nil {
 		fmt.Printf("error formating trivy scan cmd: %v", err)
@@ -56,32 +70,45 @@ func (scanner *TrivyScanner) ScanImage(ctx context.Context, imageURL string) (*r
 	type input struct {
 		URL        string
 		OutputFile string
+		Trivy      string
 	}
 
-	outJson, err := os.CreateTemp(os.TempDir(), "")
+	outJson, err := os.CreateTemp(os.Getenv("HOME"), "")
 	if err != nil {
+		fmt.Println("failed to create temp directory")
 		return nil, err
 	}
 	defer outJson.Close()
 	defer os.RemoveAll(outJson.Name())
 
 	var cmdBuf bytes.Buffer
-	cmdTmpl.Execute(&cmdBuf, input{URL: imageURL, OutputFile: outJson.Name()})
-	fmt.Printf("execute command", "cmd", cmdBuf.String())
-
-	_, err = execCmd(cmdBuf.String())
+	err = cmdTmpl.Execute(&cmdBuf, input{
+		URL:        imageURL,
+		OutputFile: outJson.Name(),
+		Trivy:      trivyPath,
+	})
 	if err != nil {
-		fmt.Printf("failed to scan image: %s, err: %v\n", imageURL, err)
-		return nil, fmt.Errorf("failed to scan image: %s", imageURL)
+		fmt.Errorf("\nerror executing trivy command template: %w", err)
 	}
 
-	vBuf, _ := os.ReadFile(outJson.Name())
-	if err := json.Unmarshal(vBuf, &vulns); err != nil {
+	fmt.Printf("Executing Trivy command: %s\n", cmdBuf.String())
+	if _, err = execCmd(cmdBuf.String()); err != nil {
+		return nil, fmt.Errorf("failed to scan image %s: %w", imageURL, err)
+	}
+
+	vBuf, err := os.ReadFile(outJson.Name())
+	if err != nil {
+		return nil, fmt.Errorf("error reading Trivy output: %w", err)
+	}
+
+	trivyRes := TrivyResult{}
+	if err := json.Unmarshal(vBuf, &trivyRes); err != nil {
 		fmt.Println(err, "error parsing json result")
 		return nil, err
 	}
 
-	updateVulnerabilityStatus(&vulnsummary, vulns)
+	updateVulnerabilityStatus(&vulnsummary, trivyRes.Results)
+
 	return &vulnsummary, nil
 }
 
@@ -111,24 +138,20 @@ func execCmd(cmdStr string) ([]byte, error) {
 	return outb.Bytes(), nil
 }
 
-func updateVulnerabilityStatus(vulns *reports.VulnerabilityData, trivy []VulnerabilityReport) {
-	total := 0
-	for _, osV := range trivy {
-		for _, v := range osV.Vulnerabilities {
-			switch v.Severity {
+func updateVulnerabilityStatus(summary *reports.VulnerabilityData, results []VulnerabilityReport) {
+	for _, report := range results {
+		for _, vuln := range report.Vulnerabilities {
+			switch strings.ToLower(vuln.Severity) {
 			case "critical":
-				vulns.Summary.Critical++
-				total++
+				summary.Summary.Critical++
 			case "high":
-				vulns.Summary.High++
-				total++
+				summary.Summary.High++
 			case "medium":
-				vulns.Summary.Medium++
-				total++
+				summary.Summary.Medium++
 			case "low":
-				vulns.Summary.Low++
-				total++
+				summary.Summary.Low++
 			}
+			summary.Summary.Total++
 		}
 	}
 }


### PR DESCRIPTION
JIRA: https://jira.devtools.intel.com/browse/IDCCOMP-4553

Changes:
- Add Trivy support for vuln scan for images
- Dynamically discover Trivy binary location
- Add summary of vulns discovered to CLI response

Evidence:
![image](https://github.com/user-attachments/assets/6e6781ef-0602-469f-ae5b-ac76984a2b7d)
